### PR TITLE
Consider the special Anonymous and Authenticated roles

### DIFF
--- a/Drivers/ContentPermissionsDisplay.cs
+++ b/Drivers/ContentPermissionsDisplay.cs
@@ -90,9 +90,19 @@ namespace Etch.OrchardCore.ContentPermissions.Drivers
 
         private bool CanAccess(ClaimsPrincipal user, string[] roles)
         {
-            if (user == null)
+            if (roles.Contains("Anonymous"))
+            {
+                return true;
+            }
+
+            if(user == null)
             {
                 return false;
+            }
+
+            if (roles.Contains("Authenticated") && user.Identity.IsAuthenticated)
+            {
+                return true;
             }
 
             foreach (var role in roles)


### PR DESCRIPTION
If the `Anonymous` role is checked, anyone should be able to view it.  If the `Authenticated` role is checked, anyone who's authenticated should be able to view it.