### PR TITLE
Moved CanAccess and GetSettings to Service

### DIFF
--- a/Etch.OrchardCore.ContentPermissions.csproj
+++ b/Etch.OrchardCore.ContentPermissions.csproj
@@ -4,7 +4,7 @@
     <TargetFramework>netcoreapp3.0</TargetFramework>
     <AddRazorSupportForMvc>true</AddRazorSupportForMvc>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-    <Version>0.1.2-rc1</Version>
+    <Version>0.1.3-rc1</Version>
     <PackageId>Etch.OrchardCore.ContentPermissions</PackageId>
     <Title>Content Permissions</Title>
     <Authors>Etch UK Ltd.</Authors>

--- a/Manifest.cs
+++ b/Manifest.cs
@@ -5,6 +5,6 @@ using OrchardCore.Modules.Manifest;
     Category = "Security",
     Description = "Configuring access at a per content item level.",
     Name = "Content Permissions",
-    Version = "0.1.2",
+    Version = "0.1.3",
     Website = "https://etchuk.com"
 )]

--- a/Services/ContentPermissionsService.cs
+++ b/Services/ContentPermissionsService.cs
@@ -1,0 +1,68 @@
+﻿using Etch.OrchardCore.ContentPermissions.Models;
+using Microsoft.AspNetCore.Http;
+using OrchardCore.ContentManagement.Metadata;
+using OrchardCore.Security.Services;
+using System;
+using System.Linq;
+
+namespace Etch.OrchardCore.ContentPermissions.Services {
+   public class ContentPermissionsService : IContentPermissionsService {
+      #region Dependencies
+
+      private readonly IContentDefinitionManager _contentDefinitionManager;
+      private readonly IHttpContextAccessor _httpContextAccessor;
+
+      #endregion
+
+      #region Constructor
+
+      public ContentPermissionsService(IContentDefinitionManager contentDefinitionManager, IHttpContextAccessor httpContextAccessor, IRoleService roleService) {
+         _contentDefinitionManager = contentDefinitionManager;
+         _httpContextAccessor = httpContextAccessor;
+      }
+
+      #endregion
+
+      #region Helpers
+
+      public bool CanAccess(ContentPermissionsPart part) {
+
+         if (part.Roles.Contains("Anonymous")) {
+            return true;
+         }
+
+         if (_httpContextAccessor.HttpContext.User == null) {
+            return false;
+         }
+
+         if (part.Roles.Contains("Authenticated") && _httpContextAccessor.HttpContext.User.Identity.IsAuthenticated) {
+            return true;
+         }
+
+         foreach (var role in part.Roles) {
+            if (_httpContextAccessor.HttpContext.User.IsInRole(role)) {
+               return true;
+            }
+         }
+
+         return false;
+      }
+
+      public ContentPermissionsPartSettings GetSettings(ContentPermissionsPart part) {
+         var contentTypeDefinition = _contentDefinitionManager.GetTypeDefinition(part.ContentItem.ContentType);
+         var contentTypePartDefinition = contentTypeDefinition.Parts.FirstOrDefault(x => string.Equals(x.PartDefinition.Name, nameof(ContentPermissionsPart)));
+         return contentTypePartDefinition.GetSettings<ContentPermissionsPartSettings>();
+      }
+
+      #endregion
+
+   }
+
+   public interface IContentPermissionsService {
+
+      bool CanAccess(ContentPermissionsPart part);
+
+      ContentPermissionsPartSettings GetSettings(ContentPermissionsPart part);
+
+   }
+}

--- a/Startup.cs
+++ b/Startup.cs
@@ -1,5 +1,6 @@
 ﻿using Etch.OrchardCore.ContentPermissions.Drivers;
 using Etch.OrchardCore.ContentPermissions.Models;
+using Etch.OrchardCore.ContentPermissions.Services;
 using Etch.OrchardCore.ContentPermissions.Settings;
 using Microsoft.Extensions.DependencyInjection;
 using OrchardCore.ContentManagement;
@@ -14,6 +15,9 @@ namespace Etch.OrchardCore.ContentPermissions
     {
         public override void ConfigureServices(IServiceCollection services)
         {
+
+            services.AddScoped<IContentPermissionsService, ContentPermissionsService>();
+            
             services.AddScoped<IContentPartDisplayDriver, ContentPermissionsDisplay>();
             services.AddContentPart<ContentPermissionsPart>();
 


### PR DESCRIPTION
In order to enforce content item security in my module's custom controllers, I needed a service I could register and use.  I could of just made it in my module but I thought it could be useful to others.