### PR TITLE
Hiding Widgets

### DIFF
--- a/Drivers/ContentPermissionsDisplay.cs
+++ b/Drivers/ContentPermissionsDisplay.cs
@@ -39,15 +39,16 @@ namespace Etch.OrchardCore.ContentPermissions.Drivers
 
         public override IDisplayResult Display(ContentPermissionsPart part, BuildPartDisplayContext context)
         {
-            if (context.DisplayType != "Detail" || !part.Enabled || _contentPermissionsService.CanAccess(part))
+            var settings = _contentPermissionsService.GetSettings(part);
+
+            if (context.DisplayType != "Detail" || !settings.HasRedirectUrl || _contentPermissionsService.CanAccess(part))
             {
                 return null;
             }
 
-            var settings = _contentPermissionsService.GetSettings(part);
-            var redirectUrl = settings.HasRedirectUrl ? settings.RedirectUrl : "/Error/403";
+            var redirectUrl = settings.RedirectUrl;
 
-            if (!redirectUrl.StartsWith("/"))
+            if (!settings.RedirectUrl.StartsWith("/"))
             {
                 redirectUrl = $"/{redirectUrl}";
             }
@@ -67,8 +68,7 @@ namespace Etch.OrchardCore.ContentPermissions.Drivers
                 model.Enabled = part.Enabled;
                 model.PossibleRoles = roles.ToArray();
                 model.Roles = part.Roles;
-            })
-            .Location("Parts#Security:10");
+            });
         }
 
         public override async Task<IDisplayResult> UpdateAsync(ContentPermissionsPart model, IUpdateModel updater, UpdatePartEditorContext context)

--- a/Liquid/UserCanViewFilter.cs
+++ b/Liquid/UserCanViewFilter.cs
@@ -1,0 +1,49 @@
+﻿using Etch.OrchardCore.ContentPermissions.Services;
+using Fluid;
+using Fluid.Values;
+using OrchardCore.ContentManagement;
+using OrchardCore.Liquid;
+using System;
+using System.Threading.Tasks;
+
+namespace Etch.OrchardCore.ContentPermissions.Liquid
+{
+    public class UserCanViewFilter : ILiquidFilter
+    {
+        #region Dependencies
+
+        private readonly IContentPermissionsService _contentPermissionsService;
+
+        #endregion
+
+        #region Constructor
+
+        public UserCanViewFilter(IContentPermissionsService contentPermissionsService)
+        {
+            _contentPermissionsService = contentPermissionsService;
+        }
+
+        #endregion
+
+        #region Implementation
+
+        public ValueTask<FluidValue> ProcessAsync(FluidValue input, FilterArguments arguments, TemplateContext context)
+        {
+            var item = input.ToObjectValue() as ContentItem;
+
+            if (item == null)
+            {
+                throw new ArgumentException("ContentItem missing while calling 'user_can_view' filter");
+            }
+
+            if (_contentPermissionsService.CanAccess(item))
+            {
+                return new ValueTask<FluidValue>(BooleanValue.True);
+            }
+
+            return new ValueTask<FluidValue>(BooleanValue.False);
+        }
+
+        #endregion
+    }
+}

--- a/README.md
+++ b/README.md
@@ -18,4 +18,41 @@ Alternatively you can [download the source](https://github.com/etchuk/Etch.Orcha
 
 ## Usage
 
-Enabled the "Content Permissions" feature, which will make a new "Content Permissions" part available. Attach this part to the desired content types, which will add a new "Security" tab to the content editor. From this tab the content item permissions can be enabled, which will display all the roles in the CMS. Select the roles that can access the content item and publish. Users not associated to one of the specified roles will receive a 403 response and redirected to `/Error/403`. The redirect URL can be customised within the settings for the content part.
+Enabled the "Content Permissions" feature, which will make a new "Content Permissions" part available. Attach this part to the desired content types, which will add a new "Security" tab to the content editor. From this tab the content item permissions can be enabled, which will display all the roles in the CMS. Select the roles that can access the content item and publish. Below are different ways of handling when the user isn't associated to one of the roles specified on the part.
+
+### Redirection
+
+Users can be redirected to a specific URL that can be defined in the settings for the content permissions part.
+
+### Display Alternative Content
+
+Users can be displayed an alternative by customising the view template, as shown below. This enables the ability to restrict whether users can see specific widgets on a page.
+
+#### Liquid
+
+Example of how to check users permission and display alternative content with Liquid template.
+
+```
+{% if Model.ContentItem | user_can_view %}
+	<p>Awesome content that you have permission to view.</p>
+{% else %}
+	<p>Unfortunately you're not able to view this content.</p>
+{% endif %}
+```
+
+#### Razor
+
+Example of how to check users permission and display alternative content with Razor template.
+
+```
+@inject Etch.OrchardCore.ContentPermissions.Services.IContentPermissionsService ContentPermissionsService
+
+@if (ContentPermissionsService.CanAccess(Model.ContentItem))
+{
+    <p>Awesome content that you have permission to view.</p>
+}
+else
+{
+    <p>Unfortunately you're not able to view this content.</p>
+}
+```

--- a/Services/ContentPermissionsService.cs
+++ b/Services/ContentPermissionsService.cs
@@ -1,5 +1,6 @@
 ﻿using Etch.OrchardCore.ContentPermissions.Models;
 using Microsoft.AspNetCore.Http;
+using OrchardCore.ContentManagement;
 using OrchardCore.ContentManagement.Metadata;
 using System;
 using System.Linq;
@@ -27,8 +28,18 @@ namespace Etch.OrchardCore.ContentPermissions.Services
 
         #region Helpers
 
+        public bool CanAccess(ContentItem contentItem)
+        {
+            return CanAccess(contentItem.As<ContentPermissionsPart>());
+        }
+
         public bool CanAccess(ContentPermissionsPart part) 
         {
+            if (part == null || !part.Enabled || !part.Roles.Any())
+            {
+                return true;
+            }
+
             if (part.Roles.Contains("Anonymous")) 
             {
                 return true;
@@ -68,6 +79,7 @@ namespace Etch.OrchardCore.ContentPermissions.Services
 
     public interface IContentPermissionsService 
     {
+        bool CanAccess(ContentItem contentItem);
         bool CanAccess(ContentPermissionsPart part);
 
         ContentPermissionsPartSettings GetSettings(ContentPermissionsPart part);

--- a/Startup.cs
+++ b/Startup.cs
@@ -1,4 +1,5 @@
 ﻿using Etch.OrchardCore.ContentPermissions.Drivers;
+using Etch.OrchardCore.ContentPermissions.Liquid;
 using Etch.OrchardCore.ContentPermissions.Models;
 using Etch.OrchardCore.ContentPermissions.Services;
 using Etch.OrchardCore.ContentPermissions.Settings;
@@ -7,6 +8,7 @@ using OrchardCore.ContentManagement;
 using OrchardCore.ContentManagement.Display.ContentDisplay;
 using OrchardCore.ContentTypes.Editors;
 using OrchardCore.Data.Migration;
+using OrchardCore.Liquid;
 using OrchardCore.Modules;
 
 namespace Etch.OrchardCore.ContentPermissions
@@ -15,13 +17,14 @@ namespace Etch.OrchardCore.ContentPermissions
     {
         public override void ConfigureServices(IServiceCollection services)
         {
-
             services.AddScoped<IContentPermissionsService, ContentPermissionsService>();
             
             services.AddScoped<IContentPartDisplayDriver, ContentPermissionsDisplay>();
             services.AddContentPart<ContentPermissionsPart>();
 
             services.AddScoped<IContentTypePartDefinitionDisplayDriver, ContentPermissionsPartSettingsDisplayDriver>();
+
+            services.AddLiquidFilter<UserCanViewFilter>("user_can_view");
 
             services.AddScoped<IDataMigration, Migrations>();
         }

--- a/Views/ContentPermissionsPartSettings.Edit.cshtml
+++ b/Views/ContentPermissionsPartSettings.Edit.cshtml
@@ -6,6 +6,6 @@
     <div class="col-lg">
         <label asp-for="RedirectUrl">@T["Redirect URL"]</label>
         <input type="text" asp-for="RedirectUrl" class="form-control" />
-        <span class="hint">@T["User will be redirected to this URL when unable to access content item. Default will redirect user to /Error/403."]</span>
+        <span class="hint">@T["User will be redirected to this URL when unable to access content item. Leave blank to disable redirect and handle user not having permission within view template."]</span>
     </div>
 </div>


### PR DESCRIPTION
Add ability to display alternative (or no) content instead of redirecting

Ideal for preventing the display of a widget for specific users. If the `ContentPermissions` part is configured with no redirect URL it's up to the view template for the content type to control what's displayed to on the page.

Added a liquid filter for checking permission of content item against the user.

(#5)