### PR TITLE
UseDisplayDriver instead of DI for ContentPermissionsDisplay

### DIFF
--- a/Startup.cs
+++ b/Startup.cs
@@ -19,8 +19,7 @@ namespace Etch.OrchardCore.ContentPermissions
         {
             services.AddScoped<IContentPermissionsService, ContentPermissionsService>();
             
-            services.AddScoped<IContentPartDisplayDriver, ContentPermissionsDisplay>();
-            services.AddContentPart<ContentPermissionsPart>();
+            services.AddContentPart<ContentPermissionsPart>().UseDisplayDriver<ContentPermissionsDisplay>();
 
             services.AddScoped<IContentTypePartDefinitionDisplayDriver, ContentPermissionsPartSettingsDisplayDriver>();
 


### PR DESCRIPTION
- fixes warning from ContentItemDisplayCoordinator that says "The content part display driver ContentPermissionsDisplay should not be registered in DI. Use UseDisplayDriver<T> instead.